### PR TITLE
feat: adequação cnpj alfanumerico

### DIFF
--- a/src/main/java/org/jrimum/domkee/pessoa/AbstractCPRF.java
+++ b/src/main/java/org/jrimum/domkee/pessoa/AbstractCPRF.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2008 JRimum Project
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
@@ -8,13 +8,13 @@
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
  * OF ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
- * 
+ *
  * Created at: 30/03/2008 - 19:03:20
- * 
+ *
  * ================================================================================
- * 
+ *
  * Direitos autorais 2008 JRimum Project
- * 
+ *
  * Licenciado sob a Licença Apache, Versão 2.0 ("LICENÇA"); você não pode usar
  * esse arquivo exceto em conformidade com a esta LICENÇA. Você pode obter uma
  * cópia desta LICENÇA em http://www.apache.org/licenses/LICENSE-2.0 A menos que
@@ -22,21 +22,20 @@
  * esta LICENÇA se dará “COMO ESTÁ”, SEM GARANTIAS OU CONDIÇÕES DE QUALQUER
  * TIPO, sejam expressas ou tácitas. Veja a LICENÇA para a redação específica a
  * reger permissões e limitações sob esta LICENÇA.
- * 
+ *
  * Criado em: 30/03/2008 - 19:03:20
- * 
+ *
  */
 package org.jrimum.domkee.pessoa;
-
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-import static org.jrimum.utilix.Strings.fillWithZeroLeft;
 
 import org.jrimum.utilix.Exceptions;
 import org.jrimum.vallia.AbstractCPRFValidator;
 import org.jrimum.vallia.AbstractCPRFValidator.TipoDeCPRF;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.jrimum.utilix.Strings.fillWithZeroLeft;
+
 /**
- *
  * <p>
  * Classe que representa um
  * <a href="http://www.receita.fazenda.gov.br/Principal/Cadastros.htm">Cadastro
@@ -53,14 +52,12 @@ import org.jrimum.vallia.AbstractCPRFValidator.TipoDeCPRF;
  * Jurídica é o CNPJ</a>.
  * </p>
  *
- *
  * @author <a href="http://gilmatryx.googlepages.com">Gilmar P.S.L.</a>
  * @author <a href="mailto:misaelbarreto@gmail.com">Misael Barreto</a>
  * @author <a href="mailto:romulomail@gmail.com">Rômulo Augusto</a>
- *
+ * @author <a href="mailto:roda7x@gmail.com">Rodrigo Carvalho</a>
+ * @version 0.3
  * @since 0.2
- *
- * @version 0.2
  */
 public abstract class AbstractCPRF implements CPRF {
 
@@ -72,7 +69,7 @@ public abstract class AbstractCPRF implements CPRF {
     /**
      *
      */
-    private Long codigo;
+    private String codigo;
 
     /**
      *
@@ -99,7 +96,7 @@ public abstract class AbstractCPRF implements CPRF {
      * {@linkplain TipoDeCPRF}.
      *
      * @param cadastroDePessoa não formatado
-     * @param tipoDeCadastro tipo
+     * @param tipoDeCadastro   tipo
      * @return AbstractCPRF (CPF ou CNPJ)
      * @throws IllegalArgumentException
      */
@@ -136,10 +133,10 @@ public abstract class AbstractCPRF implements CPRF {
      * Cria um {@linkplain CPRF} através de uma string formatada ou não.
      *
      * @param cadastroDePessoa - identificador do cadastro de pessoa formatado
-     * ou não.
+     *                         ou não.
      * @return uma instância de AbstractCPRF.
      * @throws IllegalArgumentException - caso o parâmetro não esteja em um
-     * formatador válido de cadastro de pessoa.
+     *                                  formatador válido de cadastro de pessoa.
      */
     @SuppressWarnings("unchecked")
     public static <C extends AbstractCPRF> C create(String cadastroDePessoa)
@@ -191,12 +188,12 @@ public abstract class AbstractCPRF implements CPRF {
         this.codigoFormatado = codigoFormatado;
     }
 
-    protected void setCodigo(Long codigo) {
+    protected void setCodigo(String codigo) {
 
         this.codigo = codigo;
     }
 
-    public Long getCodigo() {
+    public String getCodigo() {
         return codigo;
     }
 
@@ -214,12 +211,12 @@ public abstract class AbstractCPRF implements CPRF {
         return codigoFormatado;
     }
 
-    public Long getRaiz() {
+    public String getRaiz() {
 
         if (isFisica()) {
-            return Long.valueOf(codigoFormatado.split("-")[0].replaceAll("\\.", EMPTY));
+            return codigoFormatado.split("-")[0].replaceAll("\\.", EMPTY);
         } else {
-            return Long.valueOf(codigoFormatado.split("/")[0].replaceAll("\\.", EMPTY));
+            return codigoFormatado.split("/")[0].replaceAll("\\.", EMPTY);
         }
     }
 

--- a/src/main/java/org/jrimum/domkee/pessoa/CNPJ.java
+++ b/src/main/java/org/jrimum/domkee/pessoa/CNPJ.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2008 JRimum Project
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
@@ -8,13 +8,13 @@
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
  * OF ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
- * 
+ *
  * Created at: 30/03/2008 - 19:06:56
- * 
+ *
  * ================================================================================
- * 
+ *
  * Direitos autorais 2008 JRimum Project
- * 
+ *
  * Licenciado sob a Licença Apache, Versão 2.0 ("LICENÇA"); você não pode usar
  * esse arquivo exceto em conformidade com a esta LICENÇA. Você pode obter uma
  * cópia desta LICENÇA em http://www.apache.org/licenses/LICENSE-2.0 A menos que
@@ -22,24 +22,19 @@
  * esta LICENÇA se dará “COMO ESTÁ”, SEM GARANTIAS OU CONDIÇÕES DE QUALQUER
  * TIPO, sejam expressas ou tácitas. Veja a LICENÇA para a redação específica a
  * reger permissões e limitações sob esta LICENÇA.
- * 
+ *
  * Criado em: 30/03/2008 - 19:06:56
- * 
+ *
  */
 package org.jrimum.domkee.pessoa;
 
-import static org.apache.commons.lang3.StringUtils.isNumeric;
-import org.jrimum.ConfiguracaoJRimum;
-import static org.jrimum.utilix.Strings.fillWithZeroLeft;
-
-import org.jrimum.utilix.Exceptions;
 import org.jrimum.utilix.Objects;
 import org.jrimum.utilix.Strings;
 import org.jrimum.vallia.AbstractCPRFValidator;
-import org.jrimum.vallia.AbstractCPRFValidator.TipoDeCPRF;
+
+import static org.apache.commons.lang3.StringUtils.isNumeric;
 
 /**
- *
  * <p>
  * Representa o cadastro nacional de pssoa jurídica (CNPJ), um número
  * identificador de uma pessoa jurídica junto à Receita Federal, necessário para
@@ -52,71 +47,37 @@ import org.jrimum.vallia.AbstractCPRFValidator.TipoDeCPRF;
  * número.
  * </p>
  *
- *
  * @author <a href="http://gilmatryx.googlepages.com/">Gilmar P.S.L</a>
  * @author <a href="mailto:misaelbarreto@gmail.com">Misael Barreto</a>
  * @author <a href="mailto:romulomail@gmail.com">Rômulo Augusto</a>
- * @author <a href="http://www.nordestefomento.com.br">Nordeste Fomento
- * Mercantil</a>
- *
+ * @author <a href="http://www.nordestefomento.com.br">Nordeste Fomento Mercantil</a>
+ * @author <a href="mailto:roda7x@gmail.com">Rodrigo Carvalho</a>
+ * @version 0.3
  * @since 0.2
- *
- * @version 0.2
  */
 public class CNPJ extends AbstractCPRF {
 
-    public CNPJ(Long numCNPJ) {
-
-        try {
-
-            if (AbstractCPRFValidator.isParametrosValidos(
-                    String.valueOf(numCNPJ), TipoDeCPRF.CNPJ)) {
-
-                this.autenticadorCP = AbstractCPRFValidator.create(fillWithZeroLeft(numCNPJ, 14));
-
-                if (autenticadorCP.isValido()) {
-
-                    initFromNumber(numCNPJ);
-
-                } else {
-
-                    Exceptions.throwIllegalArgumentException("O cadastro de pessoa [ \""
-                            + numCNPJ + "\" ] não é válido.");
-                }
-            }
-
-        } catch (Exception e) {
-            if (!(e instanceof CNPJException)) {
-                throw new CNPJException(e);
-            }
-        }
-
-    }
-
     public CNPJ(String strCNPJ) {
         this.autenticadorCP = AbstractCPRFValidator.create(strCNPJ);
-        if (autenticadorCP.isValido()) {
-            init(strCNPJ);
-        } else {
-
-            if (ConfiguracaoJRimum.falharEmCPRFInvalido) {
-                throw new CNPJException(new IllegalArgumentException(
-                        "O cadastro de pessoa [ \"" + strCNPJ + "\" ] não é válido."));
-            } else {
-                init(strCNPJ);
-            }
-
+        if (!autenticadorCP.isValido()) {
+            throw new IllegalArgumentException(
+                    "O cadastro de pessoa [ " + strCNPJ + " ] não é válido.");
         }
+        init(strCNPJ.toUpperCase());
     }
 
     protected void init(String strCNPJ) {
-        if (isNumeric(strCNPJ)) {
+
+        boolean isAlphaNum = strCNPJ.matches("[0-9A-Z]{12}[0-9]{2}");
+
+        if (isNumeric(strCNPJ) || isAlphaNum) {
             initFromNotFormattedString(strCNPJ);
         } else {
             initFromFormattedString(strCNPJ);
         }
     }
 
+    @Deprecated
     public boolean isMatriz() {
 
         return getSufixoFormatado().equals("0001");
@@ -147,24 +108,13 @@ public class CNPJ extends AbstractCPRF {
         return getCodigoFormatado().split("-")[0].split("/")[1];
     }
 
-    private void initFromNumber(Long numCNPJ) {
-
-        try {
-
-            this.setCodigoFormatado(format(fillWithZeroLeft(numCNPJ, 14)));
-            this.setCodigo(numCNPJ);
-
-        } catch (Exception e) {
-            throw new CNPJException(e);
-        }
-    }
 
     private void initFromFormattedString(String strCNPJ) {
 
         try {
 
             this.setCodigoFormatado(strCNPJ);
-            this.setCodigo(Long.parseLong(removeFormat(strCNPJ)));
+            this.setCodigo(removeFormat(strCNPJ));
 
         } catch (Exception e) {
             throw new CNPJException(e);
@@ -176,7 +126,7 @@ public class CNPJ extends AbstractCPRF {
         try {
 
             this.setCodigoFormatado(format(strCNPJ));
-            this.setCodigo(Long.parseLong(strCNPJ));
+            this.setCodigo(strCNPJ);
 
         } catch (Exception e) {
             throw new CNPJException(e);

--- a/src/main/java/org/jrimum/domkee/pessoa/CPF.java
+++ b/src/main/java/org/jrimum/domkee/pessoa/CPF.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2008 JRimum Project
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
@@ -8,13 +8,13 @@
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
  * OF ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
- * 
+ *
  * Created at: 30/03/2008 - 19:07:16
- * 
+ *
  * ================================================================================
- * 
+ *
  * Direitos autorais 2008 JRimum Project
- * 
+ *
  * Licenciado sob a Licença Apache, Versão 2.0 ("LICENÇA"); você não pode usar
  * esse arquivo exceto em conformidade com a esta LICENÇA. Você pode obter uma
  * cópia desta LICENÇA em http://www.apache.org/licenses/LICENSE-2.0 A menos que
@@ -22,19 +22,18 @@
  * esta LICENÇA se dará “COMO ESTÁ”, SEM GARANTIAS OU CONDIÇÕES DE QUALQUER
  * TIPO, sejam expressas ou tácitas. Veja a LICENÇA para a redação específica a
  * reger permissões e limitações sob esta LICENÇA.
- * 
+ *
  * Criado em: 30/03/2008 - 19:07:16
- * 
+ *
  */
 package org.jrimum.domkee.pessoa;
-
-import static org.apache.commons.lang3.StringUtils.isNumeric;
-import org.jrimum.ConfiguracaoJRimum;
-import static org.jrimum.utilix.Strings.fillWithZeroLeft;
 
 import org.jrimum.utilix.Exceptions;
 import org.jrimum.vallia.AbstractCPRFValidator;
 import org.jrimum.vallia.AbstractCPRFValidator.TipoDeCPRF;
+
+import static org.apache.commons.lang3.StringUtils.isNumeric;
+import static org.jrimum.utilix.Strings.fillWithZeroLeft;
 
 /**
  * <p>
@@ -47,16 +46,13 @@ import org.jrimum.vallia.AbstractCPRFValidator.TipoDeCPRF;
  * número.
  * </p>
  *
- *
  * @author <a href="http://gilmatryx.googlepages.com/">Gilmar P.S.L</a>
  * @author <a href="mailto:misaelbarreto@gmail.com">Misael Barreto</a>
  * @author <a href="mailto:romulomail@gmail.com">Rômulo Augusto</a>
- * @author <a href="http://www.nordestefomento.com.br">Nordeste Fomento
- * Mercantil</a>
- *
+ * @author <a href="http://www.nordestefomento.com.br">Nordeste Fomento Mercantil</a>
+ * @author <a href="mailto:roda7x@gmail.com">Rodrigo Carvalho</a>
+ * @version 0.3
  * @since 0.2
- *
- * @version 0.2
  */
 public class CPF extends AbstractCPRF {
 
@@ -67,16 +63,11 @@ public class CPF extends AbstractCPRF {
 
     public CPF(String strCPF) {
         this.autenticadorCP = AbstractCPRFValidator.create(strCPF);
-        if (autenticadorCP.isValido()) {
-            init(strCPF);
-        } else {
-            if (ConfiguracaoJRimum.falharEmCPRFInvalido) {
-                throw new CPFException(new IllegalArgumentException(
-                        "O cadastro de pessoa [ \"" + strCPF + "\" ] não é válido."));
-            } else {
-                init(strCPF);
-            }
+        if (!autenticadorCP.isValido()) {
+            throw new IllegalArgumentException(
+                    "O cadastro de pessoa [ " + strCPF + " ] não é válido.");
         }
+        init(strCPF);
     }
 
     protected void init(String strCPF) {
@@ -114,7 +105,7 @@ public class CPF extends AbstractCPRF {
     private void initFromNumber(Long numCPF) {
         try {
             this.setCodigoFormatado(format(fillWithZeroLeft(numCPF, 11)));
-            this.setCodigo(numCPF);
+            this.setCodigo(String.valueOf(numCPF));
         } catch (Exception e) {
             throw new CPFException(e);
         }
@@ -123,7 +114,7 @@ public class CPF extends AbstractCPRF {
     private void initFromFormattedString(String strCPF) {
         try {
             this.setCodigoFormatado(strCPF);
-            this.setCodigo(Long.parseLong(removeFormat(strCPF)));
+            this.setCodigo(removeFormat(strCPF));
         } catch (Exception e) {
             throw new CPFException(e);
         }
@@ -132,7 +123,7 @@ public class CPF extends AbstractCPRF {
     private void initFromNotFormattedString(String strCPF) {
         try {
             this.setCodigoFormatado(format(strCPF));
-            this.setCodigo(Long.parseLong(strCPF));
+            this.setCodigo(strCPF);
         } catch (Exception e) {
             throw new CPFException(e);
         }

--- a/src/main/java/org/jrimum/domkee/pessoa/CPRF.java
+++ b/src/main/java/org/jrimum/domkee/pessoa/CPRF.java
@@ -41,13 +41,13 @@ public interface CPRF extends Comparable<Object>{
 
 	public boolean isJuridica();
 
-	public Long getCodigo();
+	public String getCodigo();
 
 	public String getCodigoComZeros();
 	
 	public String getCodigoFormatado();
 	
-	public Long getRaiz();
+	public String getRaiz();
 
 	public String getRaizComZeros();
 	

--- a/src/main/java/org/jrimum/vallia/AbstractCPRFValidator.java
+++ b/src/main/java/org/jrimum/vallia/AbstractCPRFValidator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2008 JRimum Project
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
@@ -8,13 +8,13 @@
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
  * OF ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
- * 
+ *
  * Created at: 30/03/2008 - 18:19:24
- * 
+ *
  * ================================================================================
- * 
+ *
  * Direitos autorais 2008 JRimum Project
- * 
+ *
  * Licenciado sob a Licença Apache, Versão 2.0 ("LICENÇA"); você não pode usar
  * esse arquivo exceto em conformidade com a esta LICENÇA. Você pode obter uma
  * cópia desta LICENÇA em http://www.apache.org/licenses/LICENSE-2.0 A menos que
@@ -22,18 +22,19 @@
  * esta LICENÇA se dará “COMO ESTÁ”, SEM GARANTIAS OU CONDIÇÕES DE QUALQUER
  * TIPO, sejam expressas ou tácitas. Veja a LICENÇA para a redação específica a
  * reger permissões e limitações sob esta LICENÇA.
- * 
+ *
  * Criado em: 30/03/2008 - 18:19:24
- * 
+ *
  */
 package org.jrimum.vallia;
-
-import java.io.Serializable;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jrimum.ConfiguracaoJRimum;
 import org.jrimum.utilix.ObjectUtil;
+
+import java.io.Serializable;
+import java.util.regex.Pattern;
+
 import static org.jrimum.utilix.Objects.isNotNull;
 
 /**
@@ -42,18 +43,13 @@ import static org.jrimum.utilix.Objects.isNotNull;
  * federal (CPRF).
  * </p>
  *
- *
- *
  * @author <a href="http://gilmatryx.googlepages.com/">Gilmar P.S.L</a>
  * @author Misael Barreto
  * @author Rômulo Augusto
  * @author <a href="http://www.nordeste-fomento.com.br">Nordeste Fomento
  * Mercantil</a>
- *
- * @since 0.2
- *
  * @version 0.2
- *
+ * @since 0.2
  */
 public abstract class AbstractCPRFValidator {
 
@@ -87,15 +83,14 @@ public abstract class AbstractCPRFValidator {
      * "##############".
      * </p>
      */
-    private static final String REGEX_CNPJ = "(\\d{2}\\.\\d{3}\\.\\d{3}\\/\\d{4}\\-\\d{2})|(\\d{14})";
-
+    private static final String REGEX_CNPJ = "([A-Za-z0-9]{2}\\.[A-Za-z0-9]{3}\\.[A-Za-z0-9]{3}/[A-Za-z0-9]{4}-[A-Za-z0-9]{2})|([A-Za-z0-9]{14})";
     /**
      * <p>
      * Expressão regular para validação de um cadastro: "###" ou
      * "##############".
      * </p>
      */
-    private static final String REGEX_CADASTRO = "\\d{3,14}";
+    private static final String REGEX_CADASTRO = "[A-Za-z0-9]{3,14}";
 
     /**
      * <p>
@@ -103,17 +98,13 @@ public abstract class AbstractCPRFValidator {
      * com este tipo.
      * </p>
      *
-     *
-     *
      * @author <a href="http://gilmatryx.googlepages.com/">Gilmar P.S.L</a>
      * @author Misael Barreto
      * @author Rômulo Augusto
      * @author <a href="http://www.nordeste-fomento.com.br">Nordeste Fomento
      * Mercantil</a>
-     *
-     * @since 0.2
-     *
      * @version 0.2
+     * @since 0.2
      */
     public enum TipoDeCPRF implements Serializable {
 
@@ -153,8 +144,7 @@ public abstract class AbstractCPRFValidator {
     }
 
     /**
-     * @see
-     * br.com.nordestefomento.jrimum.vallia.AbstractCPRFValidator.TipoDeCPRF
+     * @see br.com.nordestefomento.jrimum.vallia.AbstractCPRFValidator.TipoDeCPRF
      */
     @SuppressWarnings("unused")
     private TipoDeCPRF tipoDeCadastro;
@@ -193,8 +183,8 @@ public abstract class AbstractCPRFValidator {
      *
      * @param codigoDoCadastro - identificador do cadastro de pessoa.
      * @return uma instância de <code>AbstractCPRFValidator</code>.
-     * @exception IllegalArgumentException - caso o parâmetro não esteja em um
-     * formatador válido de cadastro de pessoa.
+     * @throws IllegalArgumentException - caso o parâmetro não esteja em um
+     *                                  formatador válido de cadastro de pessoa.
      * @since 0.2
      */
     public static AbstractCPRFValidator create(String codigoDoCadastro)
@@ -213,7 +203,6 @@ public abstract class AbstractCPRFValidator {
      *
      * @param tipoDeCadastro
      * @return um validador
-     *
      * @since 0.2
      */
     public static AbstractCPRFValidator create(TipoDeCPRF tipoDeCadastro) {
@@ -237,7 +226,6 @@ public abstract class AbstractCPRFValidator {
      * @param codigoDoCadastro
      * @return
      * @throws IllegalArgumentException
-     *
      * @since 0.2
      */
     private static TipoDeCPRF selectTipoDeCadastro(String codigoDoCadastro)
@@ -251,7 +239,7 @@ public abstract class AbstractCPRFValidator {
             if (StringUtils.isNotBlank(codigoDoCadastro)) {
 
                 /*
-				 * FILTRO
+                 * FILTRO
                  */
                 if (Pattern.matches(REGEX_CPF, codigoDoCadastro)) {
 
@@ -288,11 +276,10 @@ public abstract class AbstractCPRFValidator {
      * @param tipoDeCadastro
      * @return indicação de aprovação
      * @throws IllegalArgumentException
-     *
      * @since 0.2
      */
     public static boolean isParametrosValidos(String codigoDoCadastro,
-            TipoDeCPRF tipoDeCadastro) throws IllegalArgumentException {
+                                              TipoDeCPRF tipoDeCadastro) throws IllegalArgumentException {
 
         boolean isValido = false;
 
@@ -306,14 +293,14 @@ public abstract class AbstractCPRFValidator {
 
                 throw new IllegalArgumentException(
                         "O cadastro está em um tamanho incorreto ou não exsite: [ "
-                        + codigoDoCadastro + " ]");
+                                + codigoDoCadastro + " ]");
             }
         } else {
 
             throw new IllegalArgumentException(
                     "O tipo de cadastro está incorreto: [ " + tipoDeCadastro
-                    + " ] ou o cadastro não exsite: [ "
-                    + codigoDoCadastro + " ]");
+                            + " ] ou o cadastro não exsite: [ "
+                            + codigoDoCadastro + " ]");
         }
 
         return isValido;
@@ -321,13 +308,12 @@ public abstract class AbstractCPRFValidator {
 
     /**
      * <p>
-     * Recupera o cadastro de pessoa a ser validado. 
+     * Recupera o cadastro de pessoa a ser validado.
      * Obs.: A String retornada não possui formatação, ou seja, possui apenas os
      * dígitos.
      * </p>
      *
      * @return cadastro de pessoa a ser validado.
-     *
      * @since 0.2
      */
     public String getCodigoDoCadastro() {

--- a/src/main/java/org/jrimum/vallia/CNPJDV.java
+++ b/src/main/java/org/jrimum/vallia/CNPJDV.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2008 JRimum Project
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
@@ -8,13 +8,13 @@
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
  * OF ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
- * 
+ *
  * Created at: 30/03/2008 - 18:22:39
- * 
+ *
  * ================================================================================
- * 
+ *
  * Direitos autorais 2008 JRimum Project
- * 
+ *
  * Licenciado sob a Licença Apache, Versão 2.0 ("LICENÇA"); você não pode usar
  * esse arquivo exceto em conformidade com a esta LICENÇA. Você pode obter uma
  * cópia desta LICENÇA em http://www.apache.org/licenses/LICENSE-2.0 A menos que
@@ -22,16 +22,16 @@
  * esta LICENÇA se dará “COMO ESTÁ”, SEM GARANTIAS OU CONDIÇÕES DE QUALQUER
  * TIPO, sejam expressas ou tácitas. Veja a LICENÇA para a redação específica a
  * reger permissões e limitações sob esta LICENÇA.
- * 
+ *
  * Criado em: 30/03/2008 - 18:22:39
- * 
+ *
  */
 package org.jrimum.vallia;
 
-import java.util.regex.Pattern;
-
 import org.apache.commons.lang3.StringUtils;
 import org.jrimum.texgit.Filler;
+
+import java.util.regex.Pattern;
 
 /**
  * <p>
@@ -44,10 +44,10 @@ import org.jrimum.texgit.Filler;
  * <h3>Exemplo para um número hipotético 11.222.333/0001-XX:</h3>
  * <p>
  * Primeiramente obtém-se um número R, calculado através da rotina de módulo 11,
- * a partir dos doze primeiros números do CNPJ, nesse caso 112223330001. 
+ * a partir dos doze primeiros números do CNPJ, nesse caso 112223330001.
  * Para obter o primeiro dígito verificador deve-se seguir a seguinte lógica:
- * 
- * 
+ * <p>
+ * <p>
  * Se o número R for menor que 2, o dígito terá valor 0 (zero); senão, será a
  * subtração do valor do módulo (11) menos o valor do número R, ou seja,
  * <code>DV = 11 - R</code>.
@@ -61,17 +61,14 @@ import org.jrimum.texgit.Filler;
  * Obs.: O limite mínimo e máximo do módulo 11 são 2 e 9, respectivamente.
  * </p>
  *
- * @see Modulo
- *
  * @author <a href="http://gilmatryx.googlepages.com/">Gilmar P.S.L</a>
  * @author Misael Barreto
  * @author Rômulo Augusto
- * @author <a href="http://www.nordeste-fomento.com.br">Nordeste Fomento
- * Mercantil</a>
- *
+ * @author <a href="http://www.nordeste-fomento.com.br">Nordeste Fomento Mercantil</a>
+ * @author <a href="mailto:roda7x@gmail.com">Rodrigo Carvalho</a>
+ * @version 0.3
+ * @see Modulo
  * @since 0.2
- *
- * @version 0.2
  */
 public class CNPJDV extends AbstractDigitoVerificador {
 
@@ -100,19 +97,18 @@ public class CNPJDV extends AbstractDigitoVerificador {
      * formatação: "############".
      * </p>
      */
-    private static final String REGEX_CNPJ_DV = "\\d{12}";
+    private static final String REGEX_CNPJ_DV = "[A-Z0-9]{12}";
 
     /**
      * <p>
-     * Expressão regular para validação dos doze primeiros números do CNPJ
+     * Expressão regular para validação dos doze primeiros digitos alfanuméricos do CNPJ
      * formatado: "##.###.###/####".
      * </p>
      */
-    private static final String REGEX_CNPJ_DV_FORMATTED = "\\d{2}\\.\\d{3}\\.\\d{3}\\/\\d{4}";
+    private static final String REGEX_CNPJ_DV_FORMATTED = "[A-Za-z0-9]{2}\\.[A-Za-z0-9]{3}\\.[A-Za-z0-9]{3}/[A-Za-z0-9]{4}";
 
     /**
-     * @see
-     * br.com.nordestefomento.jrimum.vallia.digitoverificador.AbstractDigitoVerificador#calcule(long)
+     * @see br.com.nordestefomento.jrimum.vallia.digitoverificador.AbstractDigitoVerificador#calcule(long)
      * @since 0.2
      */
     @Override
@@ -122,78 +118,78 @@ public class CNPJDV extends AbstractDigitoVerificador {
     }
 
     /**
-     * @see
-     * br.com.nordestefomento.jrimum.vallia.digitoverificador.AbstractDigitoVerificador#calcule(java.lang.String)
-     * @since 0.2
+     * Calcula os dois dígitos verificadores (DV) de um CNPJ a partir da base informada.
+     * <p>
+     * Aceita CNPJ numérico ou alfanumérico, com ou sem máscara. O valor é normalizado
+     * para maiúsculas e tem os caracteres não alfanuméricos removidos antes do cálculo.
+     * O método valida se a base possui exatamente 12 caracteres e identifica
+     * automaticamente se o cálculo deve seguir a regra numérica (tradicional) ou
+     * alfanumérica (novo padrão).
+     * </p>
+     *
+     * @param numero CNPJ base (12 caracteres), podendo estar formatado ou não.
+     * @return Os dois dígitos verificadores concatenados (ex: {@code 75}).
+     * @throws IllegalArgumentException Se o CNPJ for nulo, vazio, inválido ou não
+     *                                  atender ao formato esperado após normalização.
+     * @since 0.3
      */
     @Override
     public int calcule(String numero) throws IllegalArgumentException {
 
-        int dv1 = 0;
-        int dv2 = 0;
+        if (StringUtils.isBlank(numero)) {
+            throw new IllegalArgumentException(
+                    "O CNPJ esta vazio ou invalido");
+        }
 
-        boolean isFormatoValido = false;
+        String base12 = numero.toUpperCase().replaceAll("[^0-9A-Z]", "");
 
-        validacao:
-        {
-
-            if (StringUtils.isNotBlank(numero)) {
-
-                isFormatoValido = (Pattern.matches(REGEX_CNPJ_DV, numero) || Pattern
-                        .matches(REGEX_CNPJ_DV_FORMATTED, numero));
-
-                if (isFormatoValido) {
-
-                    numero = StringUtils.replaceChars(numero, ".", "");
-                    numero = StringUtils.replaceChars(numero, "/", "");
-
-                    dv1 = calculeDigito(numero);
-                    dv2 = calculeDigito(numero + dv1);
-
-                    break validacao;
-                }
-            }
-
+        if (!Pattern.matches(REGEX_CNPJ_DV, base12)) {
             throw new IllegalArgumentException(
                     "O CNPJ [ "
-                    + numero
-                    + " ] deve conter apenas números, sendo eles no formato ##.###.###/#### ou ############ !");
+                            + numero
+                            + " ] é invalido");
+        }
 
+        boolean isNumerico = base12.matches("[0-9]{12}");
+
+        int dv1 = calculeDigito(base12, 12, isNumerico);
+        int dv2 = calculeDigito(base12 + dv1, 13, isNumerico);
+
+        if (dv1 < 0 || (dv2 < 0)) {
+            throw new IllegalArgumentException(
+                    "O CNPJ [ "
+                            + numero
+                            + " ] é invalido");
         }
 
         return Integer.parseInt(dv1 + "" + dv2);
 
     }
 
-    /**
-     * <p>
-     * Método auxiliar para o cálculo do dígito verificador.
-     * </p>
-     * <p>
-     * Calcula os dígitos separadamente.
-     * </p>
-     *
-     * @param numero - número a partir do qual será extraído o dígito
-     * verificador.
-     * @return Um número que faz parte de um dígito verificador.
-     * @throws IllegalArgumentException caso o número não esteja no formatador
-     * desejável.
-     *
-     * @since 0.2
-     */
-    private int calculeDigito(String numero) throws IllegalArgumentException {
 
-        int dv = 0;
-        int resto = 0;
+    private static int calculeDigito(String cnpj, int tamanho, boolean isNumerico) {
+        int soma = 0;
+        int peso = 2;
 
-        resto = Modulo.calculeMod11(numero, LIMITE_MINIMO, LIMITE_MAXIMO);
+        for (int i = tamanho - 1; i >= 0; i--) {
+            char c = cnpj.charAt(i);
 
-        if (resto >= 2) {
+            int valor;
+            if (isNumerico) {
+                if (c < '0' || c > '9') return -1;
+                valor = c - '0';
+            } else {
+                if (!((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z'))) return -1;
+                valor = ((int) c) - 48;
+            }
 
-            dv = TipoDeModulo.MODULO11.valor() - resto;
+            soma += valor * peso;
+            peso++;
+            if (peso > 9) peso = 2;
         }
 
-        return dv;
+        int resto = soma % 11;
+        return (resto < 2) ? 0 : (11 - resto);
     }
 
 }

--- a/src/test/java/com/github/braully/boleto/TestBoletoFacade.java
+++ b/src/test/java/com/github/braully/boleto/TestBoletoFacade.java
@@ -20,8 +20,8 @@ import org.junit.Test;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
- *
  * @author braully
  */
 public class TestBoletoFacade {
@@ -29,9 +29,9 @@ public class TestBoletoFacade {
     @Test
     public void testBoletoSimples() {
         BoletoCobranca boletoFacade = new BoletoCobranca();
-        boletoFacade.sacado("Sacado da Silva Sauro").sacadoCpf("1");
+        boletoFacade.sacado("Sacado da Silva Sauro").sacadoCpf("7068093868");
         boletoFacade.banco("1").agencia("1").conta("1");
-        boletoFacade.cedente("Cedente da Silva Sauro").cedenteCnpj("1");
+        boletoFacade.cedente("Cedente da Silva Sauro").cedenteCnpj("60746948000112");
         //boletoFacade.covenio("1");
         boletoFacade.carteira("1");
         boletoFacade.numeroDocumento("1")
@@ -48,9 +48,9 @@ public class TestBoletoFacade {
     @Test
     public void testBoletoSicredi() {
         BoletoCobranca boletoFacade = new BoletoCobranca();
-        boletoFacade.sacado("Sacado da Silva Sauro").sacadoCpf("1");
+        boletoFacade.sacado("Sacado da Silva Sauro").sacadoCpf("07068093868");
         boletoFacade.banco("748").agencia("1").conta("1").carteira("1");
-        boletoFacade.cedente("Cedente da Silva Sauro").cedenteCnpj("1");
+        boletoFacade.cedente("Cedente da Silva Sauro").cedenteCnpj("60746948000112");
         //boletoFacade.covenio("1");
         boletoFacade.carteira("1");
         boletoFacade.numeroDocumento("1")
@@ -72,9 +72,9 @@ public class TestBoletoFacade {
     public void testBoletoBancoBradesco() {
         BoletoCobranca boletoFacade = new BoletoCobranca();
         boletoFacade.sacado("Teste da silva Sauro")
-                .sacadoCpf("1");
+                .sacadoCpf("07068093868");
         boletoFacade.banco("237").agencia("4534-9").conta("188-999");
-        boletoFacade.cedente("Cedente da Silva Sauro").cedenteCnpj("1");
+        boletoFacade.cedente("Cedente da Silva Sauro").cedenteCnpj("60746948000112");
         boletoFacade.carteira("1");
         boletoFacade.numeroDocumento("1")
                 .nossoNumero("12345678901")
@@ -104,9 +104,9 @@ public class TestBoletoFacade {
     @Test
     public void testBoletoBancoCaixa() {
         BoletoCobranca boletoFacade = new BoletoCobranca();
-        boletoFacade.sacado("Sacado da Silva Sauro").sacadoCpf("1");
+        boletoFacade.sacado("Sacado da Silva Sauro").sacadoCpf("07068093868");
         boletoFacade.banco("104").agencia("1").conta("1");
-        boletoFacade.cedente("Cedente da Silva Sauro").cedenteCnpj("1");
+        boletoFacade.cedente("Cedente da Silva Sauro").cedenteCnpj("22.413.806/0001-44");
         //boletoFacade.covenio("1");
         boletoFacade.carteira("1");
         boletoFacade.numeroDocumento("1")
@@ -123,9 +123,9 @@ public class TestBoletoFacade {
     @Test
     public void testBoletoBancoItau() {
         BoletoCobranca boletoFacade = new BoletoCobranca();
-        boletoFacade.sacado("Sacado da Silva Sauro").sacadoCpf("1");
+        boletoFacade.sacado("Sacado da Silva Sauro").sacadoCpf("07068093868");
         boletoFacade.banco("341").agencia("1").conta("1");
-        boletoFacade.cedente("Cedente da Silva Sauro").cedenteCnpj("1");
+        boletoFacade.cedente("Cedente da Silva Sauro").cedenteCnpj("Y9.T2X.T5C/0001-37");
         //boletoFacade.covenio("1");
         boletoFacade.carteira("1");
         boletoFacade.numeroDocumento("1")

--- a/src/test/java/org/jrimum/domkee/comum/pessoa/id/cprf/TestAbstractCPRF.java
+++ b/src/test/java/org/jrimum/domkee/comum/pessoa/id/cprf/TestAbstractCPRF.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2008 JRimum Project
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
@@ -8,13 +8,13 @@
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
  * OF ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
- * 
+ *
  * Created at: 30/03/2008 - 19:11:04
- * 
+ *
  * ================================================================================
- * 
+ *
  * Direitos autorais 2008 JRimum Project
- * 
+ *
  * Licenciado sob a Licença Apache, Versão 2.0 ("LICENÇA"); você não pode usar
  * esse arquivo exceto em conformidade com a esta LICENÇA. Você pode obter uma
  * cópia desta LICENÇA em http://www.apache.org/licenses/LICENSE-2.0 A menos que
@@ -22,9 +22,9 @@
  * esta LICENÇA se dará “COMO ESTÁ”, SEM GARANTIAS OU CONDIÇÕES DE QUALQUER
  * TIPO, sejam expressas ou tácitas. Veja a LICENÇA para a redação específica a
  * reger permissões e limitações sob esta LICENÇA.
- * 
+ *
  * Criado em: 30/03/2008 - 19:11:04
- * 
+ *
  */
 
 
@@ -32,317 +32,231 @@ package org.jrimum.domkee.comum.pessoa.id.cprf;
 
 import org.jrimum.domkee.pessoa.AbstractCPRF;
 import org.jrimum.domkee.pessoa.CPRF;
-import static org.jrimum.utilix.Strings.fillWithZeroLeft;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import org.jrimum.vallia.AbstractCPRFValidator.TipoDeCPRF;
 import org.junit.Test;
+
+import static org.jrimum.utilix.Strings.fillWithZeroLeft;
+import static org.junit.Assert.*;
 
 
 /**
  * Teste da classe {@linkplain AbstractCPRF} e base para as sublcasses {@linkplain CPF} e {@linkplain CNPJ}.
- * 
- * @author <a href="http://gilmatryx.googlepages.com/">Gilmar P.S.L.</a> 
- * 
- * @since 0.2
- * 
+ *
+ * @author <a href="http://gilmatryx.googlepages.com/">Gilmar P.S.L.</a>
  * @version 0.2
+ * @since 0.2
  */
-public abstract class TestAbstractCPRF{
+public abstract class TestAbstractCPRF {
+
+    private TipoDeCPRF tipo;
+    private String cprfStringFormatada;
+    private String cprfStringFormatadaErr;
+    private String cprfString;
+    private String cprfStringErr;
+    private String cprfRaizFormatada;
+    private String cprfRaizFormatadaErr;
+    private Integer cprfDv;
+    private Integer cprfDvErr;
+
+    private CPRF cprf;
+    private CPRF cprfOutro;
+
+
+    @Test
+    public void testCreateStringTipoDeCPRF() {
+        assertNotNull(AbstractCPRF.create(cprfString, tipo));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDoNotCreateStringTipoDeCPRF() {
+        assertNotNull(AbstractCPRF.create(cprfStringErr, tipo));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDoNotCreateStringFormatadaTipoDeCPRF() {
+        assertNotNull(AbstractCPRF.create(cprfStringFormatada, tipo));
+    }
+
+    @Test
+    public void testCreateString() {
+        assertNotNull(AbstractCPRF.create(cprfString));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDoNotCreateString() {
+        assertNotNull(AbstractCPRF.create(cprfStringErr));
+    }
+
+    @Test
+    public void testCreateStringFormatada() {
+        assertNotNull(AbstractCPRF.create(cprfStringFormatada));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDoNotCreateStringFormatada() {
+        assertNotNull(AbstractCPRF.create(cprfStringFormatadaErr));
+    }
+
+    @Test
+    public void testIsFisica() {
+        assertTipo();
+    }
+
+    @Test
+    public void testIsJuridica() {
+        assertTipo();
+    }
+
+
+    @Test
+    public void testGetCodigoFormatado() {
+        assertEquals(cprfStringFormatada, cprf.getCodigoFormatado());
+        assertTrue(!cprf.getCodigoFormatado().equals(cprfStringFormatadaErr));
+    }
 	
-	private TipoDeCPRF tipo;
-	private String cprfStringFormatada;
-	private String cprfStringFormatadaErr;
-	private String cprfString;
-	private String cprfStringErr;
-	private Long cprfLong;
-	private Long cprfLongErr;
-	private Long cprfRaizLong;
-	private Long cprfRaizLongErr;
-	private String cprfRaizFormatada;
-	private String cprfRaizFormatadaErr;
-	private Integer cprfDv;
-	private Integer cprfDvErr;
-	
-	private CPRF cprf;
-	private CPRF cprfOutro;
-		
-	@Test
-	public final void testCreateLongTipoDeCPRF() {
-		assertNotNull(AbstractCPRF.create(cprfLong, tipo));
-	}
 
-	@Test(expected=IllegalArgumentException.class)
-	public final void testDoNotCreateLongTipoDeCPRF() {
-		assertNotNull(AbstractCPRF.create(cprfLongErr, tipo));
-	}
+    @Test
+    public void testGetRaizFormatada() {
+        assertEquals(cprfRaizFormatada, cprf.getRaizFormatada());
+        assertTrue(!cprf.getRaizComZeros().equals(cprfRaizFormatadaErr));
+    }
 
-	@Test
-	public void testCreateStringTipoDeCPRF() {
-		assertNotNull(AbstractCPRF.create(cprfString, tipo));
-	}
+    @Test
+    public void testGetDv() {
+        assertEquals(cprfDv, cprf.getDv());
+        assertTrue(!cprf.getDv().equals(cprfDvErr));
+    }
 
-	@Test(expected=IllegalArgumentException.class)
-	public void testDoNotCreateStringTipoDeCPRF() {
-		assertNotNull(AbstractCPRF.create(cprfStringErr, tipo));
-	}
-	
-	@Test(expected=IllegalArgumentException.class)
-	public void testDoNotCreateStringFormatadaTipoDeCPRF() {
-		assertNotNull(AbstractCPRF.create(cprfStringFormatada, tipo));
-	}
+    @Test
+    public void testGetDvComZeros() {
+        assertEquals(fillWithZeroLeft(cprf.getDv(), 2), cprf.getDvComZeros());
+        assertTrue(!cprf.getDvComZeros().equals(fillWithZeroLeft(cprfDvErr, 2)));
+    }
 
-	@Test
-	public void testCreateString() {
-		assertNotNull(AbstractCPRF.create(cprfString));
-	}
-	
-	@Test(expected=IllegalArgumentException.class)
-	public void testDoNotCreateString() {
-		assertNotNull(AbstractCPRF.create(cprfStringErr));
-	}
+    @Test
+    public void testCompareTo() {
+        int c1 = this.cprf.compareTo(this.cprfOutro);
+        int c2 = this.cprfOutro.compareTo(this.cprf);
+        assertTrue(c1 != c2);
+        assertTrue(cprf.compareTo(AbstractCPRF.create(cprf.getCodigoFormatado())) == 0);
+    }
 
-	@Test
-	public void testCreateStringFormatada() {
-		assertNotNull(AbstractCPRF.create(cprfStringFormatada));
-	}
-	
-	@Test(expected=IllegalArgumentException.class)
-	public void testDoNotCreateStringFormatada() {
-		assertNotNull(AbstractCPRF.create(cprfStringFormatadaErr));
-	}
+    @Test
+    public void testEqualsObject() {
+        assertEquals(cprf, AbstractCPRF.create(cprf.getCodigoFormatado()));
+        assertTrue(!cprf.equals(cprfOutro));
+    }
 
-	@Test
-	public void testIsFisica() {
-		assertTipo();
-	}
+    @Test
+    public void testHashCode() {
+        assertEquals(cprf.hashCode(), AbstractCPRF.create(cprf.getCodigoFormatado()).hashCode());
+        assertTrue(cprf.hashCode() != cprfOutro.hashCode());
+    }
 
-	@Test
-	public void testIsJuridica() {
-		assertTipo();
-	}
+    @Test
+    public void testToString() {
 
-	@Test
-	public void testGetCodigo() {
-		assertEquals(cprfLong, cprf.getCodigo());
-	}
+        assertEquals(cprfStringFormatada, cprf.getCodigoFormatado());
+        assertTrue(!cprf.getCodigoFormatado().equals(cprfStringFormatadaErr));
+    }
+    /*
+     * HELPERS
+     */
 
-	@Test
-	public void testGetCodigoComZeros() {
-		
-		int tamanho = -1;
-		
-		if(cprf.isFisica()){			
-			tamanho = 11;
-		}else{
-			tamanho = 14;
-		}
+    private void assertTipo() {
 
-		assertEquals(fillWithZeroLeft(cprfLong, tamanho), cprf.getCodigoComZeros());
-		assertTrue(!cprf.getCodigoComZeros().equals(fillWithZeroLeft(cprfLongErr, tamanho)));
-	}
+        if (tipo.equals(TipoDeCPRF.CPF)) {
+            assertTrue(cprf.isFisica());
+            assertTrue(!cprf.isJuridica());
+        } else {
 
-	@Test
-	public void testGetCodigoFormatado() {
-		assertEquals(cprfStringFormatada, cprf.getCodigoFormatado());
-		assertTrue(!cprf.getCodigoFormatado().equals(cprfStringFormatadaErr));
-	}
+            if (tipo.equals(TipoDeCPRF.CNPJ)) {
+                assertTrue(cprf.isJuridica());
+                assertTrue(!cprf.isFisica());
+            } else {
+                fail("TIPO NÃO PREVISTO PELO PROGRAMA!");
+            }
+        }
+    }
 
-	@Test
-	public void testGetRaiz() {
-		assertEquals(cprfRaizLong, cprf.getRaiz());
-		assertTrue(cprf.getRaiz().longValue() == cprfRaizLong.longValue());
-		assertTrue(!cprf.getRaiz().equals(cprfLongErr));
-	}
+    /*
+     * DEFINERS
+     */
 
-	@Test
-	public void testGetRaizComZeros() {
-		
-		int tamanho = -1;
-		
-		if(cprf.isFisica()){			
-			tamanho = 9;
-		}else{
-			tamanho = 8;
-		}
-		
-		assertEquals(fillWithZeroLeft(cprfRaizLong, tamanho), cprf.getRaizComZeros());
-		assertTrue(!cprf.getRaizComZeros().equals(fillWithZeroLeft(cprfRaizLongErr,tamanho)));
-	}
+    /**
+     * @param tipo the tipo to set
+     */
+    public final void setTipo(TipoDeCPRF tipo) {
+        this.tipo = tipo;
+    }
 
-	@Test
-	public void testGetRaizFormatada() {
-		assertEquals(cprfRaizFormatada, cprf.getRaizFormatada());
-		assertTrue(!cprf.getRaizComZeros().equals(cprfRaizFormatadaErr));
-	}
+    /**
+     * @param cprfStringFormatada the cprfStringFormatada to set
+     */
+    public final void setCprfStringFormatada(String cprfStringFormatada) {
+        this.cprfStringFormatada = cprfStringFormatada;
+    }
 
-	@Test
-	public void testGetDv() {
-		assertEquals(cprfDv, cprf.getDv());
-		assertTrue(!cprf.getDv().equals(cprfDvErr));
-	}
+    /**
+     * @param cprfStringFormatadaErr the cprfStringFormatadaErr to set
+     */
+    public final void setCprfStringFormatadaErr(String cprfStringFormatadaErr) {
+        this.cprfStringFormatadaErr = cprfStringFormatadaErr;
+    }
 
-	@Test
-	public void testGetDvComZeros() {
-		assertEquals(fillWithZeroLeft(cprf.getDv(),2), cprf.getDvComZeros());
-		assertTrue(!cprf.getDvComZeros().equals(fillWithZeroLeft(cprfDvErr,2)));
-	}
+    /**
+     * @param cprfString the cprfString to set
+     */
+    public final void setCprfString(String cprfString) {
+        this.cprfString = cprfString;
+    }
 
-	@Test
-	public void testCompareTo() {
-		int c1 = this.cprf.compareTo(this.cprfOutro);
-		int c2 = this.cprfOutro.compareTo(this.cprf);
-		assertTrue(c1 != c2);
-		assertTrue(cprf.compareTo(AbstractCPRF.create(cprf.getCodigoFormatado())) == 0);
-	}
+    /**
+     * @param cprfStringErr the cprfStringErr to set
+     */
+    public final void setCprfStringErr(String cprfStringErr) {
+        this.cprfStringErr = cprfStringErr;
+    }
 
-	@Test
-	public void testEqualsObject() {
-		assertEquals(cprf, AbstractCPRF.create(cprf.getCodigoFormatado()));
-		assertTrue(!cprf.equals(cprfOutro));
-	}
-	
-	@Test
-	public void testHashCode() {
-		assertEquals(cprf.hashCode(), AbstractCPRF.create(cprf.getCodigoFormatado()).hashCode());
-		assertTrue(cprf.hashCode() != cprfOutro.hashCode());
-	}
+    /**
+     * @param cprfRaizFormatada the cprfRaizFormatado to set
+     */
+    public final void setCprfRaizFormatada(String cprfRaizFormatada) {
+        this.cprfRaizFormatada = cprfRaizFormatada;
+    }
 
-	@Test
-	public void testToString() {
-		
-		assertEquals(cprfStringFormatada, cprf.getCodigoFormatado());
-		assertTrue(!cprf.getCodigoFormatado().equals(cprfStringFormatadaErr));
-	}
-	/*
-	 * HELPERS
-	 */
-	
-	private void assertTipo(){
-		
-		if(tipo.equals(TipoDeCPRF.CPF)){
-			assertTrue(cprf.isFisica());
-			assertTrue(!cprf.isJuridica());
-		}else{
-			
-			if(tipo.equals(TipoDeCPRF.CNPJ)){
-				assertTrue(cprf.isJuridica());
-				assertTrue(!cprf.isFisica());
-			}else{
-				fail("TIPO NÃO PREVISTO PELO PROGRAMA!");				
-			}
-		}
-	}
-	
-	/*
-	 * DEFINERS 
-	 */
-	
-	/**
-	 * @param tipo the tipo to set
-	 */
-	public final void setTipo(TipoDeCPRF tipo) {
-		this.tipo = tipo;
-	}
+    /**
+     * @param cprfRaizFormatadaErr the cprfRaizFormatadoErr to set
+     */
+    public final void setCprfRaizFormatadaErr(String cprfRaizFormatadaErr) {
+        this.cprfRaizFormatadaErr = cprfRaizFormatadaErr;
+    }
 
-	/**
-	 * @param cprfStringFormatada the cprfStringFormatada to set
-	 */
-	public final void setCprfStringFormatada(String cprfStringFormatada) {
-		this.cprfStringFormatada = cprfStringFormatada;
-	}
+    /**
+     * @param cprfDv the cprfDv to set
+     */
+    public final void setCprfDv(Integer cprfDv) {
+        this.cprfDv = cprfDv;
+    }
 
-	/**
-	 * @param cprfStringFormatadaErr the cprfStringFormatadaErr to set
-	 */
-	public final void setCprfStringFormatadaErr(String cprfStringFormatadaErr) {
-		this.cprfStringFormatadaErr = cprfStringFormatadaErr;
-	}
+    /**
+     * @param cprfDvErr the cprfDvErr to set
+     */
+    public final void setCprfDvErr(Integer cprfDvErr) {
+        this.cprfDvErr = cprfDvErr;
+    }
 
-	/**
-	 * @param cprfString the cprfString to set
-	 */
-	public final void setCprfString(String cprfString) {
-		this.cprfString = cprfString;
-	}
+    /**
+     * @param cprf the cprf to set
+     */
+    public final void setCprf(CPRF cprf) {
+        this.cprf = cprf;
+    }
 
-	/**
-	 * @param cprfStringErr the cprfStringErr to set
-	 */
-	public final void setCprfStringErr(String cprfStringErr) {
-		this.cprfStringErr = cprfStringErr;
-	}
-
-	/**
-	 * @param cprfLong the cprfLong to set
-	 */
-	public final void setCprfLong(Long cprfLong) {
-		this.cprfLong = cprfLong;
-	}
-
-	/**
-	 * @param cprfLongErr the cprfLongErr to set
-	 */
-	public final void setCprfLongErr(Long cprfLongErr) {
-		this.cprfLongErr = cprfLongErr;
-	}
-
-	/**
-	 * @param cprfRaizLong the cprfRaizLong to set
-	 */
-	public final void setCprfRaizLong(Long cprfRaizLong) {
-		this.cprfRaizLong = cprfRaizLong;
-	}
-
-	/**
-	 * @param cprfRaizLongErr the cprfRaizLongErr to set
-	 */
-	public final void setCprfRaizLongErr(Long cprfRaizLongErr) {
-		this.cprfRaizLongErr = cprfRaizLongErr;
-	}
-
-	/**
-	 * @param cprfRaizFormatada the cprfRaizFormatado to set
-	 */
-	public final void setCprfRaizFormatada(String cprfRaizFormatada) {
-		this.cprfRaizFormatada = cprfRaizFormatada;
-	}
-
-	/**
-	 * @param cprfRaizFormatadaErr the cprfRaizFormatadoErr to set
-	 */
-	public final void setCprfRaizFormatadaErr(String cprfRaizFormatadaErr) {
-		this.cprfRaizFormatadaErr = cprfRaizFormatadaErr;
-	}
-
-	/**
-	 * @param cprfDv the cprfDv to set
-	 */
-	public final void setCprfDv(Integer cprfDv) {
-		this.cprfDv = cprfDv;
-	}
-
-	/**
-	 * @param cprfDvErr the cprfDvErr to set
-	 */
-	public final void setCprfDvErr(Integer cprfDvErr) {
-		this.cprfDvErr = cprfDvErr;
-	}
-
-	/**
-	 * @param cprf the cprf to set
-	 */
-	public final void setCprf(CPRF cprf) {
-		this.cprf = cprf;
-	}
-	
-	/**
-	 * @param cprfOutro the cprfOutro to set
-	 */
-	public final void setCprfOutro(CPRF cprfOutro) {
-		this.cprfOutro = cprfOutro;
-	}
+    /**
+     * @param cprfOutro the cprfOutro to set
+     */
+    public final void setCprfOutro(CPRF cprfOutro) {
+        this.cprfOutro = cprfOutro;
+    }
 }

--- a/src/test/java/org/jrimum/domkee/comum/pessoa/id/cprf/TestCNPJ.java
+++ b/src/test/java/org/jrimum/domkee/comum/pessoa/id/cprf/TestCNPJ.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2008 JRimum Project
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
@@ -8,13 +8,13 @@
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
  * OF ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
- * 
+ *
  * Created at: 30/03/2008 - 19:11:13
- * 
+ *
  * ================================================================================
- * 
+ *
  * Direitos autorais 2008 JRimum Project
- * 
+ *
  * Licenciado sob a Licença Apache, Versão 2.0 ("LICENÇA"); você não pode usar
  * esse arquivo exceto em conformidade com a esta LICENÇA. Você pode obter uma
  * cópia desta LICENÇA em http://www.apache.org/licenses/LICENSE-2.0 A menos que
@@ -22,139 +22,119 @@
  * esta LICENÇA se dará “COMO ESTÁ”, SEM GARANTIAS OU CONDIÇÕES DE QUALQUER
  * TIPO, sejam expressas ou tácitas. Veja a LICENÇA para a redação específica a
  * reger permissões e limitações sob esta LICENÇA.
- * 
+ *
  * Criado em: 30/03/2008 - 19:11:13
- * 
+ *
  */
 
 package org.jrimum.domkee.comum.pessoa.id.cprf;
 
 import org.jrimum.domkee.pessoa.CNPJ;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import org.jrimum.vallia.AbstractCPRFValidator.TipoDeCPRF;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.*;
+
 /**
  * Teste da classe CNPJ.
- * 
+ *
  * @author <a href="http://gilmatryx.googlepages.com/">Gilmar P.S.L.</a>
- * 
- * @since 2.0
- * 
  * @version 2.0
+ * @since 2.0
  */
-public class TestCNPJ extends TestAbstractCPRF{
+public class TestCNPJ extends TestAbstractCPRF {
 
-	/*
-	 * CNPJ: 60.746.948/0001-12 | BANCO BRADESCO
-	 */
-	private final String cnpjBradescoFilialStrFmt = "60.746.948/0005-46"; 	
-	private final String cnpjBradescoStrFmt = "60.746.948/0001-12"; 	
-	private final String cnpjBradescoStr = "60746948000112"; 	
-	private final Long cnpjBradesco = 60746948000112L; 	
-	
-	@Before
-	public void setUp() {
-		
-		setTipo(TipoDeCPRF.CNPJ);
-		setCprfLong(cnpjBradesco);
-		setCprfLongErr(60746948000113L);
-		setCprfString(cnpjBradescoStr);
-		setCprfStringErr("60746948000113");
-		setCprfStringFormatada(cnpjBradescoStrFmt);
-		setCprfStringFormatadaErr("60.746.948/0001-13");
-		setCprfRaizLong(60746948L);
-		setCprfRaizLongErr(60746941L);
-		setCprfRaizFormatada("60.746.948");
-		setCprfRaizFormatadaErr("60.746.941");
-		setCprfDv(12);
-		setCprfDvErr(13);
-		setCprf(new CNPJ(cnpjBradescoStrFmt));
-		 //BANCO DO NORDESTE
-		setCprfOutro(new CNPJ("07.237.373/0001-20"));
-	}
+    /*
+     * CNPJ: 60.746.948/0001-12 | BANCO BRADESCO
+     */
+    private final String cnpjBradescoFilialStrFmt = "60.746.948/0005-46";
+    private final String cnpjBradescoStrFmt = "60.746.948/0001-12";
+    private final String cnpjBradescoStr = "60746948000112";
 
-	/**
-	 * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CNPJ#CNPJ(java.lang.Long)}.
-	 */
-	@Test
-	public void testCNPJLong() {
-		CNPJ cnpj = new CNPJ(cnpjBradesco);
-		assertConsistent(cnpj);
-	}
+    @Before
+    public void setUp() {
 
-	/**
-	 * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CNPJ#CNPJ(java.lang.String)}.
-	 */
-	@Test
-	public void testCNPJStringWithZeros() {
-		CNPJ cnpj = new CNPJ(cnpjBradescoStr);
-		assertConsistent(cnpj);
-	}
+        setTipo(TipoDeCPRF.CNPJ);
+        setCprfString(cnpjBradescoStr);
+        setCprfStringErr("60746948000113");
+        setCprfStringFormatada(cnpjBradescoStrFmt);
+        setCprfStringFormatadaErr("60.746.948/0001-13");
+        setCprfRaizFormatada("60.746.948");
+        setCprfRaizFormatadaErr("60.746.941");
+        setCprfDv(12);
+        setCprfDvErr(13);
+        setCprf(new CNPJ(cnpjBradescoStrFmt));
+        //BANCO DO NORDESTE
+        setCprfOutro(new CNPJ("07.237.373/0001-20"));
+    }
 
-	/**
-	 * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CNPJ#CNPJ(java.lang.String)}.
-	 */
-	@Test
-	public void testCNPJStringWithFormat() {
-		CNPJ cnpj = new CNPJ(cnpjBradescoStrFmt);
-		assertConsistent(cnpj);
-	}
-	
-	/**
-	 * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CNPJ#getSufixo()}.
-	 */
-	@Test
-	public void testGetSufixo() {
-		assertEquals(Integer.valueOf(1), new CNPJ(cnpjBradescoStrFmt).getSufixo());
-		
-	}
+    /**
+     * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CNPJ#CNPJ(java.lang.String)}.
+     */
+    @Test
+    public void testCNPJStringWithZeros() {
+        CNPJ cnpj = new CNPJ(cnpjBradescoStr);
+        assertConsistent(cnpj);
+    }
 
-	/**
-	 * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CNPJ#getSufixoFormatado()}.
-	 */
-	@Test
-	public void testGetSufixoFormatado() {
-		assertEquals("0001", new CNPJ(cnpjBradescoStrFmt).getSufixoFormatado());
-	}
+    /**
+     * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CNPJ#CNPJ(java.lang.String)}.
+     */
+    @Test
+    public void testCNPJStringWithFormat() {
+        CNPJ cnpj = new CNPJ(cnpjBradescoStrFmt);
+        assertConsistent(cnpj);
+    }
 
-	/**
-	 * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CNPJ#isMatriz()}.
-	 */
-	@Test
-	public void testIsMatriz() {
-		assertTrue(new CNPJ(cnpjBradescoStrFmt).isMatriz());
-		assertTrue(!new CNPJ(cnpjBradescoFilialStrFmt).isMatriz());
-	}
+    /**
+     * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CNPJ#getSufixo()}.
+     */
+    @Test
+    public void testGetSufixo() {
+        assertEquals(Integer.valueOf(1), new CNPJ(cnpjBradescoStrFmt).getSufixo());
 
-	/**
-	 * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CNPJ#isSufixoEquals(java.lang.String)}.
-	 */
-	@Test
-	public void testIsSufixoEqualsString() {
-		
-		assertTrue(new CNPJ(cnpjBradescoStrFmt).isSufixoEquals("0001"));
-		assertTrue(!new CNPJ(cnpjBradescoFilialStrFmt).isSufixoEquals("0001"));
-	}
+    }
 
-	/**
-	 * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CNPJ#isSufixoEquals(java.lang.Integer)}.
-	 */
-	@Test
-	public void testIsSufixoEqualsInteger() {
-		assertTrue(new CNPJ(cnpjBradescoFilialStrFmt).isSufixoEquals(5));
-		assertTrue(!new CNPJ(cnpjBradescoStrFmt).isSufixoEquals(5));
-	}
+    /**
+     * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CNPJ#getSufixoFormatado()}.
+     */
+    @Test
+    public void testGetSufixoFormatado() {
+        assertEquals("0001", new CNPJ(cnpjBradescoStrFmt).getSufixoFormatado());
+    }
 
-	private void assertConsistent(CNPJ cnpj) {
-		
-		assertNotNull(cnpj);
-		assertEquals(cnpjBradesco, cnpj.getCodigo());
-		assertEquals(cnpjBradescoStr, cnpj.getCodigoComZeros());
-		assertEquals(cnpjBradescoStrFmt, cnpj.getCodigoFormatado());
-	}
+    /**
+     * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CNPJ#isMatriz()}.
+     */
+    @Test
+    public void testIsMatriz() {
+        assertTrue(new CNPJ(cnpjBradescoStrFmt).isMatriz());
+        assertTrue(!new CNPJ(cnpjBradescoFilialStrFmt).isMatriz());
+    }
+
+    /**
+     * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CNPJ#isSufixoEquals(java.lang.String)}.
+     */
+    @Test
+    public void testIsSufixoEqualsString() {
+
+        assertTrue(new CNPJ(cnpjBradescoStrFmt).isSufixoEquals("0001"));
+        assertTrue(!new CNPJ(cnpjBradescoFilialStrFmt).isSufixoEquals("0001"));
+    }
+
+    /**
+     * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CNPJ#isSufixoEquals(java.lang.Integer)}.
+     */
+    @Test
+    public void testIsSufixoEqualsInteger() {
+        assertTrue(new CNPJ(cnpjBradescoFilialStrFmt).isSufixoEquals(5));
+        assertTrue(!new CNPJ(cnpjBradescoStrFmt).isSufixoEquals(5));
+    }
+    
+    private void assertConsistent(CNPJ cnpj) {
+        assertNotNull(cnpj);
+        assertEquals(cnpjBradescoStr, cnpj.getCodigoComZeros());
+        assertEquals(cnpjBradescoStrFmt, cnpj.getCodigoFormatado());
+    }
 }

--- a/src/test/java/org/jrimum/domkee/comum/pessoa/id/cprf/TestCNPJAlfanumerico.java
+++ b/src/test/java/org/jrimum/domkee/comum/pessoa/id/cprf/TestCNPJAlfanumerico.java
@@ -1,0 +1,79 @@
+package org.jrimum.domkee.comum.pessoa.id.cprf;
+
+import org.jrimum.domkee.pessoa.CNPJ;
+import org.jrimum.vallia.AbstractCPRFValidator.TipoDeCPRF;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class TestCNPJAlfanumerico extends TestAbstractCPRF {
+
+    private final String cnpjAlfaStr = "SGU1GE72000175";
+    private final String cnpjAlfaStrFmt = "SG.U1G.E72/0001-75";
+    private final String cnpjAlfaStrErr = "SGU1GE72000100";
+    private final String cnpjAlfaStrFmtErr = "SG.U1G.E72/0001-00";
+
+    @Before
+    public void setUp() {
+
+        setTipo(TipoDeCPRF.CNPJ);
+
+        setCprfString(cnpjAlfaStr);
+        setCprfStringErr(cnpjAlfaStrErr);
+
+        setCprfStringFormatada(cnpjAlfaStrFmt);
+        setCprfStringFormatadaErr(cnpjAlfaStrFmtErr);
+        setCprfRaizFormatada("SG.U1G.E72");
+        setCprfRaizFormatadaErr("SG.U1G.E73");
+
+        setCprfDv(75);
+        setCprfDvErr(0);
+
+        setCprf(new CNPJ(cnpjAlfaStrFmt));
+
+        setCprfOutro(new CNPJ("07.237.373/0001-20"));
+    }
+
+
+    @Test
+    public void testCNPJAlfanumericoStringSemMascara() {
+        CNPJ cnpj = new CNPJ(cnpjAlfaStr);
+
+        assertNotNull(cnpj);
+        assertEquals(cnpjAlfaStr, cnpj.getCodigoComZeros());
+        assertEquals(cnpjAlfaStrFmt, cnpj.getCodigoFormatado());
+    }
+
+
+    @Test
+    public void testCNPJAlfanumericoStringComMascara() {
+        CNPJ cnpj = new CNPJ(cnpjAlfaStrFmt);
+
+        assertNotNull(cnpj);
+        assertEquals(cnpjAlfaStr, cnpj.getCodigoComZeros());
+        assertEquals(cnpjAlfaStrFmt, cnpj.getCodigoFormatado());
+    }
+
+    @Test
+    public void testCNPJAlfanumericoMinusculoDeveNormalizar() {
+        CNPJ cnpj = new CNPJ("sg.u1g.e72/0001-75");
+
+        assertNotNull(cnpj);
+        assertEquals(cnpjAlfaStr, cnpj.getCodigoComZeros());
+        assertEquals(cnpjAlfaStrFmt, cnpj.getCodigoFormatado());
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCNPJAlfanumericoDvInvalidoSemMascaraDeveFalhar() {
+        new CNPJ(cnpjAlfaStrErr);
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCNPJAlfanumericoDvInvalidoComMascaraDeveFalhar() {
+        new CNPJ(cnpjAlfaStrFmtErr);
+    }
+}

--- a/src/test/java/org/jrimum/domkee/comum/pessoa/id/cprf/TestCPF.java
+++ b/src/test/java/org/jrimum/domkee/comum/pessoa/id/cprf/TestCPF.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2008 JRimum Project
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
@@ -8,13 +8,13 @@
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
  * OF ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
- * 
+ *
  * Created at: 30/03/2008 - 19:11:24
- * 
+ *
  * ================================================================================
- * 
+ *
  * Direitos autorais 2008 JRimum Project
- * 
+ *
  * Licenciado sob a Licença Apache, Versão 2.0 ("LICENÇA"); você não pode usar
  * esse arquivo exceto em conformidade com a esta LICENÇA. Você pode obter uma
  * cópia desta LICENÇA em http://www.apache.org/licenses/LICENSE-2.0 A menos que
@@ -22,92 +22,85 @@
  * esta LICENÇA se dará “COMO ESTÁ”, SEM GARANTIAS OU CONDIÇÕES DE QUALQUER
  * TIPO, sejam expressas ou tácitas. Veja a LICENÇA para a redação específica a
  * reger permissões e limitações sob esta LICENÇA.
- * 
+ *
  * Criado em: 30/03/2008 - 19:11:24
- * 
+ *
  */
 
 package org.jrimum.domkee.comum.pessoa.id.cprf;
 
 import org.jrimum.domkee.pessoa.CPF;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import org.jrimum.vallia.AbstractCPRFValidator.TipoDeCPRF;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 /**
  * Teste da classe CPF.
- * 
+ *
  * @author <a href="http://gilmatryx.googlepages.com/">Gilmar P.S.L.</a>
- * 
- * @since 0.2
- * 
  * @version 0.2
+ * @since 0.2
  */
-public class TestCPF extends TestAbstractCPRF{
-	
-	/*
-	 * CPF: 070.680.938-68 | LUIZ INACIO LULA DA SILVA
-	 */
-	private final String cpfLulaStrFmt = "070.680.938-68"; 	
-	private final String cpfLulaStr = "07068093868"; 	
-	private final Long cpfLula = 7068093868L; 	
-	
-	@Before
-	public void setUp() {
-		
-		setTipo(TipoDeCPRF.CPF);
-		setCprfLong(cpfLula);
-		setCprfLongErr(7068093867L);
-		setCprfString(cpfLulaStr);
-		setCprfStringErr("07068093867");
-		setCprfStringFormatada(cpfLulaStrFmt);
-		setCprfStringFormatadaErr("070.680.938-67");
-		setCprfRaizLong(70680938L);
-		setCprfRaizLongErr(70680936L);
-		setCprfRaizFormatada("070.680.938");
-		setCprfRaizFormatadaErr("070.680.936");
-		setCprfDv(68);
-		setCprfDvErr(67);
-		setCprf(new CPF(cpfLulaStrFmt));
-		 //FICTICIO
-		setCprfOutro(new CPF("222.222.222-22"));
-	}
-	
-	/**
-	 * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CPF#CPF(java.lang.Long)}.
-	 */
-	@Test
-	public void testCPFLong() {
-		CPF cpf = new CPF(cpfLula);
-		assertConsistent(cpf);
-	}
+public class TestCPF extends TestAbstractCPRF {
 
-	/**
-	 * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CPF#CPF(java.lang.String)}.
-	 */
-	@Test
-	public void testCPFStringWithZeros() {
-		CPF cpf = new CPF(cpfLulaStr);
-		assertConsistent(cpf);
-	}
+    /*
+     * CPF: 070.680.938-68 | LUIZ INACIO LULA DA SILVA
+     */
+    private final String cpfLulaStrFmt = "070.680.938-68";
+    private final String cpfLulaStr = "07068093868";
+    private final Long cpfLula = 7068093868L;
 
-	/**
-	 * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CPF#CPF(java.lang.String)}.
-	 */
-	@Test
-	public void testCPFStringWithFormat() {
-		CPF cpf = new CPF(cpfLulaStrFmt);
-		assertConsistent(cpf);
-	}
+    @Before
+    public void setUp() {
 
-	private void assertConsistent(CPF cpf) {
-		
-		assertNotNull(cpf);
-		assertEquals(cpfLula, cpf.getCodigo());
-		assertEquals(cpfLulaStr, cpf.getCodigoComZeros());
-		assertEquals(cpfLulaStrFmt, cpf.getCodigoFormatado());
-	}
+        setTipo(TipoDeCPRF.CPF);
+        setCprfString(cpfLulaStr);
+        setCprfStringErr("07068093867");
+        setCprfStringFormatada(cpfLulaStrFmt);
+        setCprfStringFormatadaErr("070.680.938-67");
+        setCprfRaizFormatada("070.680.938");
+        setCprfRaizFormatadaErr("070.680.936");
+        setCprfDv(68);
+        setCprfDvErr(67);
+        setCprf(new CPF(cpfLulaStrFmt));
+        //FICTICIO
+        setCprfOutro(new CPF("222.222.222-22"));
+    }
+
+    /**
+     * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CPF#CPF(java.lang.Long)}.
+     */
+    @Test
+    public void testCPFLong() {
+        CPF cpf = new CPF(cpfLula);
+        assertConsistent(cpf);
+    }
+
+    /**
+     * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CPF#CPF(java.lang.String)}.
+     */
+    @Test
+    public void testCPFStringWithZeros() {
+        CPF cpf = new CPF(cpfLulaStr);
+        assertConsistent(cpf);
+    }
+
+    /**
+     * Test method for {@link org.jrimum.domkee.comum.pessoa.id.cprf.CPF#CPF(java.lang.String)}.
+     */
+    @Test
+    public void testCPFStringWithFormat() {
+        CPF cpf = new CPF(cpfLulaStrFmt);
+        assertConsistent(cpf);
+    }
+
+    private void assertConsistent(CPF cpf) {
+
+        assertNotNull(cpf);
+        assertEquals(cpfLulaStr, cpf.getCodigoComZeros());
+        assertEquals(cpfLulaStrFmt, cpf.getCodigoFormatado());
+    }
 }


### PR DESCRIPTION
- [x] - Adicionado suporte a CNPJ alfanumérico
- [x] - Normalização da entrada (maiúsculas e remoção de caracteres não alfanuméricos)
- [x] - Regex e validações atualizadas para aceitar formato alfanumérico com e sem máscara
- [x] - Cálculo de dígito verificador compatível com o novo padrão e com o formato numérico
- [x] - Método de identificação de Matriz/Filial marcado como @Deprecated, pois não é mais confiável no padrão alfanumérico
- [x] - Testes adicionados para cenários válidos e inválidos de CNPJ alfanumérico